### PR TITLE
Add simple Flask login app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,38 @@
-# PROG8850Template
-environment with mysql, python, node and docker
+# Sample Login App
 
-TLDR;
+This repository contains a simple Flask web application with a login form that inserts user credentials into a MySQL database. A Selenium script demonstrates how to automate the login process and verify the database entry.
+
+## Setup
+
+1. Install dependencies:
 
 ```bash
 pip install -r requirements.txt
-sudo service mysql start
 ```
 
-To access database:
+2. Start a MySQL server. The included example expects a server running locally on port `3307` with a root user and no password. You can start a temporary server with:
 
 ```bash
-sudo mysql -u root
+mysqld --initialize-insecure --datadir=/workspace/mysqldata
+mysqld --datadir=/workspace/mysqldata --socket=/workspace/mysqldata/mysql.sock --port=3307 --skip-networking=0 &
 ```
 
-happy mysql!
+3. Create the database and table:
+
+```bash
+mysql --socket=/workspace/mysqldata/mysql.sock -u root -e "CREATE DATABASE testapp; USE testapp; CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255), password VARCHAR(255));"
+```
+
+4. Run the Flask app:
+
+```bash
+python app.py
+```
+
+5. Optionally run the Selenium test (requires Firefox and geckodriver):
+
+```bash
+python test_login.py
+```
+
+The test will open a browser, submit the login form with a sample user, and then query the database to show the inserted row.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,46 @@
+from flask import Flask, request, render_template_string, redirect
+import mysql.connector
+
+app = Flask(__name__)
+
+def get_db_connection():
+    return mysql.connector.connect(
+        host='localhost',
+        port=3307,
+        user='root',
+        password='',
+        database='testapp',
+        unix_socket='/workspace/mysqldata/mysql.sock'
+    )
+
+HTML_FORM = '''
+<!doctype html>
+<title>Login</title>
+<h1>Login Form</h1>
+<form method="post">
+  Username: <input type="text" name="username"><br>
+  Password: <input type="password" name="password"><br>
+  <input type="submit" value="Login">
+</form>
+'''
+
+@app.route('/', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("INSERT INTO users (username, password) VALUES (%s, %s)", (username, password))
+        conn.commit()
+        cursor.close()
+        conn.close()
+        return redirect('/success')
+    return render_template_string(HTML_FORM)
+
+@app.route('/success')
+def success():
+    return 'Login successful!'
+
+if __name__ == '__main__':
+    app.run(debug=True, port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+flask
+selenium
 mysql-connector-python

--- a/test_login.py
+++ b/test_login.py
@@ -1,0 +1,32 @@
+import time
+import mysql.connector
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+# start the flask app in a subprocess
+import subprocess, os
+
+app_proc = subprocess.Popen(['python', 'app.py'], env=dict(os.environ, FLASK_ENV='production'))
+
+time.sleep(2)  # give server time to start
+
+try:
+    driver = webdriver.Firefox()
+    driver.get('http://localhost:5000/')
+    driver.find_element(By.NAME, 'username').send_keys('testuser')
+    driver.find_element(By.NAME, 'password').send_keys('secret')
+    driver.find_element(By.CSS_SELECTOR, 'input[type=submit]').click()
+    time.sleep(1)
+finally:
+    driver.quit()
+    app_proc.terminate()
+    app_proc.wait()
+
+# check database for inserted user
+conn = mysql.connector.connect(host='localhost', port=3307, user='root', password='', database='testapp', unix_socket='/workspace/mysqldata/mysql.sock')
+cur = conn.cursor()
+cur.execute("SELECT username, password FROM users WHERE username=%s", ('testuser',))
+result = cur.fetchone()
+print(result)
+cur.close()
+conn.close()


### PR DESCRIPTION
## Summary
- add Flask app that stores form results in MySQL
- add Selenium script that automates the login
- update requirements with flask and selenium
- document how to run the app and Selenium test

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py test_login.py`
- `python test_login.py` *(fails: WebDriverException)*

------
https://chatgpt.com/codex/tasks/task_e_684b4a4a0cb88333afed2c67f1751d8f